### PR TITLE
chore: add ownership-guard action

### DIFF
--- a/.github/workflows/ownership.yml
+++ b/.github/workflows/ownership.yml
@@ -1,0 +1,16 @@
+name: Ownership
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  ownership:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Package Ownership
+        uses: flaticols/ownership-guard@v5.0.0

--- a/.ownership
+++ b/.ownership
@@ -1,0 +1,39 @@
+team: core
+@flaticols/core
+
+=ownership:
+internal/**
+cmd/**
+!internal/tui/**
+!internal/treeview/**
+
+=template:
+<!-- ownership-bot: core -->
+> [!IMPORTANT]
+> `{pkg}` is part of the analysis engine owned by **{team}**. {author}, please coordinate with {members} — changes here affect the core refactoring logic.
+
+team: tui
+@flaticols/core
+
+=ownership:
+internal/tui/**
+internal/treeview/**
+
+=template:
+<!-- ownership-bot: tui -->
+> [!NOTE]
+> `{pkg}` is owned by the **{team}** team. {author}, loop in {members} — UI changes should be reviewed for keyboard, rendering, and accessibility consistency.
+
+team: infra
+@flaticols/core
+
+=ownership:
+nix/**
+flake.nix
+flake.lock
+.goreleaser.yaml
+
+=template:
+<!-- ownership-bot: infra -->
+> [!WARNING]
+> `{pkg}` is owned by **{team}**. {author}, please align with {members} before merging — nix changes affect the binary packaging and release pipeline.

--- a/internal/loader/loader.go
+++ b/internal/loader/loader.go
@@ -1,3 +1,4 @@
+// Package loader builds the call graph and package dependency graph.
 package loader
 
 import (

--- a/internal/rules/check.go
+++ b/internal/rules/check.go
@@ -1,3 +1,4 @@
+// Package rules provides rule checking and validation utilities.
 package rules
 
 import (

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -1,3 +1,4 @@
+// Package tui implements the terminal user interface.
 package tui
 
 import "github.com/charmbracelet/bubbles/key"

--- a/nix/gorefact.nix
+++ b/nix/gorefact.nix
@@ -1,5 +1,5 @@
 # This file is auto-updated by GoReleaser on each release.
-# Do not edit manually — changes will be overwritten.
+# Do not edit manually — changes will be overwritten on next release.
 { lib, stdenvNoCC, fetchurl }:
 let
   version = "0.0.17";


### PR DESCRIPTION
Adds `flaticols/ownership-guard@v2.0.0` to enforce cross-team ownership awareness on PRs.

## What this does

- Adds `.ownership` file defining the `core` team with ownership over `internal/**` and `cmd/**`
- Adds `.github/workflows/ownership.yml` that runs on every PR

## Testing

This draft PR itself is the test — the ownership workflow should fire and post a warning comment if the PR author is not in the `core` team.

## `.ownership` syntax

```
team: core
@flaticols/core

=ownership:
internal/**
cmd/**
```