### PR TITLE
docs: match release archive arch naming to published artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ go tool gorefact ./...
 
 ### Release archives
 
-Tagged releases publish `tar.gz` archives for macOS (`amd64`, `arm64`) on the [releases page](https://github.com/flaticols/gorefactor/releases).
+Tagged releases publish `tar.gz` archives for macOS (`x86_64`, `arm64`) on the [releases page](https://github.com/flaticols/gorefactor/releases).
 
 ---
 


### PR DESCRIPTION
Small README tweak: the macOS release archives are named `gorefact_Darwin_x86_64.tar.gz` / `gorefact_Darwin_arm64.tar.gz`, so refer to `x86_64` instead of `amd64`.

Opened to get a fresh commit on `main` for re-tagging the release.